### PR TITLE
fix gallery path

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -175,6 +175,10 @@ app.get("/impact", (req, res) => {
   res.sendFile(path.join(__dirname, "../public/pages/impact.html"));
 });
 
+app.get("/gallery", (req, res) => {
+  res.sendFile(path.join(__dirname, "../public/pages/gallery.html"));
+});
+
 // Endpoint to fetch impact stories
 app.get("/api/impact-stories", async (req, res) => {
   try {


### PR DESCRIPTION
needed to add this block in app.js to fix the gallery path
``` js
app.get("/gallery", (req, res) => {
  res.sendFile(path.join(__dirname, "../public/pages/gallery.html"));
});
```